### PR TITLE
Implement wifi printer snackbar and listing

### DIFF
--- a/app/src/main/java/com/example/printerswanqaratest/data/database/DatabaseProvider.kt
+++ b/app/src/main/java/com/example/printerswanqaratest/data/database/DatabaseProvider.kt
@@ -1,0 +1,21 @@
+package com.example.printerswanqaratest.data.database
+
+import android.content.Context
+import androidx.room.Room
+
+object DatabaseProvider {
+    @Volatile
+    private var INSTANCE: DBConnection? = null
+
+    fun getDatabase(context: Context): DBConnection {
+        return INSTANCE ?: synchronized(this) {
+            val instance = Room.databaseBuilder(
+                context.applicationContext,
+                DBConnection::class.java,
+                "printers_db"
+            ).build()
+            INSTANCE = instance
+            instance
+        }
+    }
+}

--- a/app/src/main/java/com/example/printerswanqaratest/ui/screens/list/ListPrintersScreen.kt
+++ b/app/src/main/java/com/example/printerswanqaratest/ui/screens/list/ListPrintersScreen.kt
@@ -1,15 +1,43 @@
 package com.example.printerswanqaratest.ui.screens.list
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import com.example.printerswanqaratest.data.database.DatabaseProvider
+import com.example.printerswanqaratest.data.database.repositories.PrinterRepository
+import com.example.printerswanqaratest.domain.models.Printers
+import com.example.printerswanqaratest.domain.services.GetAllPrinters
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @Composable
 fun ListPrintersScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(text = "List Printers Screen")
+    val context = LocalContext.current
+    var printers by remember { mutableStateOf<List<Printers>>(emptyList()) }
+
+    LaunchedEffect(Unit) {
+        printers = withContext(Dispatchers.IO) {
+            val db = DatabaseProvider.getDatabase(context)
+            val repository = PrinterRepository(db.printersDAO())
+            val getAll = GetAllPrinters(repository)
+            getAll.getAll()
+        }
+    }
+
+    if (printers.isEmpty()) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(text = "No printers saved")
+        }
+    } else {
+        LazyColumn(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            items(printers) { printer ->
+                Text(text = printer.name)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- show snackbar notifications when saving WiFi printers
- load saved printers in `ListPrintersScreen`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686b514e6c2083258cdaf88676660dbe